### PR TITLE
Include license file

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ test:
 about:
   home: http://funcsigs.readthedocs.org
   license: Apache 2.0
+  license_file: LICENSE
   summary: Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: python setup.py install --single-version-externally-managed --record=record.txt
 


### PR DESCRIPTION
Make sure the package contains the license file.